### PR TITLE
🐛 Fix: API 주소 수정 JYXB-384

### DIFF
--- a/src/main/java/org/example/productadminservice/category/presentation/CategoryController.java
+++ b/src/main/java/org/example/productadminservice/category/presentation/CategoryController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RestController
 @Tag(name = "카테고리 관리 API", description = "카테고리 관련 API endpoints")
-@RequestMapping("/v1/admin/category")
+@RequestMapping("/v1/admin/product-admin/category")
 public class CategoryController {
 
 	private final CategoryService categoryService;

--- a/src/main/java/org/example/productadminservice/llm/presentation/LLMController.java
+++ b/src/main/java/org/example/productadminservice/llm/presentation/LLMController.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/admin/llm")
+@RequestMapping("/v1/admin/product-admin/llm")
 @Tag(name = "LLM 관리 API", description = "LLM 관련 API endpoints")
 public class LLMController {
 

--- a/src/main/java/org/example/productadminservice/llm/presentation/LLMVersionController.java
+++ b/src/main/java/org/example/productadminservice/llm/presentation/LLMVersionController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/admin/llm/version")
+@RequestMapping("/v1/admin/product-admin/llm/version")
 @Tag(name = "LLM 버전 관리", description = "LLM 버전 관리 API")
 public class LLMVersionController {
 

--- a/src/main/java/org/example/productadminservice/product/presentation/ProductController.java
+++ b/src/main/java/org/example/productadminservice/product/presentation/ProductController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "상품 관리 API", description = "상품 관련 API endpoints")
-@RequestMapping("/v1/admin/product")
+@RequestMapping("/v1/admin/product-admin")
 public class ProductController {
 
 	private final ProductService productService;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c569a0a1-b7fb-44ea-98b4-966d4d3d1229)
이 형태로 API endpoint 주소 사용하면 Gateway Routing이 안 되는 문제가 있어요
Eureka Client 명을 주소 안에 넣어줘야 돌아갑니다

그런 이유로 PR을 올렸으니 참고부탁드려요

This pull request includes changes to the API endpoint mappings for several controllers to ensure consistency in the URL paths. The most important changes are as follows:

### Endpoint Mapping Updates:

* [`CategoryController`](diffhunk://#diff-d46b3a39afb23014ea1af83e8117feeb32fa432597ae0d6a87202edf5eae8b46L26-R26): Updated the `@RequestMapping` path from `/v1/admin/category` to `/v1/admin/product-admin/category`.
* [`LLMController`](diffhunk://#diff-30f9b5568c31fad2726acf12b6362a997f510d79633dcefc1794ae139eed92fbL23-R23): Updated the `@RequestMapping` path from `/v1/admin/llm` to `/v1/admin/product-admin/llm`.
* [`LLMVersionController`](diffhunk://#diff-6a4612d11860fba796ef8e594fc0e899d95fa7b5222a466a7ed814e8a32ec195L21-R21): Updated the `@RequestMapping` path from `/v1/admin/llm/version` to `/v1/admin/product-admin/llm/version`.
* [`ProductController`](diffhunk://#diff-9dc03d3309f23020211b4cae5c3db0211b7c39b11118f7c901d2fdc27a1d84a5L18-R18): Updated the `@RequestMapping` path from `/v1/admin/product` to `/v1/admin/product-admin`.